### PR TITLE
IPAD-00089H -> IPAD-00089

### DIFF
--- a/GymRoom/GymRoom/Feature/GymRoomFeature+AlertState.swift
+++ b/GymRoom/GymRoom/Feature/GymRoomFeature+AlertState.swift
@@ -1,0 +1,30 @@
+//
+//  GymRoomFeature+AlertState.swift
+//  GymRoom
+//
+//  Created by Sebastian Ściuba on 13/06/2026.
+//
+
+import ComposableArchitecture
+import Foundation
+
+/// Alert states for `GymRoomFeature`.
+extension AlertState where Action == GymRoomFeature.Action.Alert {
+
+    /// Confirmation dialog before ending the class — prevents accidental tap
+    /// that would disconnect all athletes mid-session. Destructive style on End
+    /// button + cancel role on Cancel button (Apple system styling: red destructive,
+    /// bold cancel).
+    static let endClass = Self {
+        TextState(String(localized: "End class?", bundle: .main))
+    } actions: {
+        ButtonState(role: .destructive, action: .confirmEnd) {
+            TextState(String(localized: "End", bundle: .main))
+        }
+        ButtonState(role: .cancel) {
+            TextState(String(localized: "Cancel", bundle: .main))
+        }
+    } message: {
+        TextState(String(localized: "All athletes will be disconnected.", bundle: .main))
+    }
+}

--- a/GymRoom/GymRoom/Feature/GymRoomFeature.swift
+++ b/GymRoom/GymRoom/Feature/GymRoomFeature.swift
@@ -62,18 +62,8 @@ GymRoomFeature {
 
             case .view(.endTapped):
                 // Tap End → present confirm dialog. Faktyczna end logic w `.alert(.presented(.confirmEnd))`.
-                state.alert = AlertState(
-                    title: { TextState(String(localized: "End class?", bundle: .main)) },
-                    actions: {
-                        ButtonState(role: .destructive, action: .confirmEnd) {
-                            TextState(String(localized: "End", bundle: .main))
-                        }
-                        ButtonState(role: .cancel) {
-                            TextState(String(localized: "Cancel", bundle: .main))
-                        }
-                    },
-                    message: { TextState(String(localized: "All athletes will be disconnected.", bundle: .main)) }
-                )
+                // Alert content w `GymRoomFeature+AlertState.swift` jako static `.endClass`.
+                state.alert = .endClass
                 return .none
 
             case .alert(.presented(.confirmEnd)):


### PR DESCRIPTION
IPAD-00089 H: Bi-directional class lifecycle (host→peer broadcast + peer self-reset)