### PR TITLE
IPAD-00097 -> develop

### DIFF
--- a/GymRoom/GymRoom/Features/LiveClass/Feature/LiveClassFeature+State.swift
+++ b/GymRoom/GymRoom/Features/LiveClass/Feature/LiveClassFeature+State.swift
@@ -17,8 +17,9 @@ extension LiveClassFeature {
         /// Czy klasa jest aktywna (advertising w sieci lokalnej, kafelki widoczne).
         var isLive: Bool = false
 
-        /// End-confirmed until results present — stops the view dropping to the idle
-        /// "Start Class" screen (which flashes) during the BLE recap grace + teardown.
+        /// True from End-confirmed until the feature is dismissed — keeps the spinner
+        /// behind the results cover so the view never drops to the idle "Start Class"
+        /// screen (which otherwise flashes) during finalize + results present.
         var isFinalizing: Bool = false
 
         /// Lista podłączonych athletów. Klucz = `deviceID` (per-install UUID peer'a).

--- a/GymRoom/GymRoom/Features/LiveClass/Feature/LiveClassFeature.swift
+++ b/GymRoom/GymRoom/Features/LiveClass/Feature/LiveClassFeature.swift
@@ -225,7 +225,10 @@ struct LiveClassFeature {
                 )
 
             case let .resultsReady(rows):
-                state.isFinalizing = false
+                // Keep `isFinalizing` true so the spinner stays BEHIND the results
+                // cover — clearing it here would reveal the idle "Start Class" screen
+                // during the cover's present animation. The whole feature is torn down
+                // on `.classEnded` (parent sets `liveClass = nil`), so no reset needed.
                 state.results = ClassResultsFeature.State(className: state.className, rows: rows)
                 return .none
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1301,6 +1301,6 @@
     - added a dedicated finalizing state so the view shows a "Kończenie zajęć…" spinner during finalization instead of dropping to idle; cleared once the results cover is presented
     - visual-only: results, recap and analytics were always computed correctly
 
-    A: `isFinalizing` flag on `LiveClassFeature.State` — set on End-confirmed (alongside `isLive=false`), cleared in `.resultsReady`; `LiveClassView` gains an `else if isFinalizing { finalizingView }` branch (ProgressView + localized label)
+    A: `isFinalizing` flag on `LiveClassFeature.State` — set on End-confirmed (alongside `isLive=false`), stays true BEHIND the results cover (clearing it in `.resultsReady` flashed the idle screen during the cover's present animation) and is torn down with the feature on `.classEnded`; `LiveClassView` gains an `else if isFinalizing { finalizingView }` branch (ProgressView + localized label)
 
     Noticed (separate follow-up): the end handler uses a raw `Date()` instead of `@Dependency(\.date.now)` — controlled-deps hygiene, not addressed here


### PR DESCRIPTION
IPAD-00097 GymRoom end-flow — finalizing state removes "Start Class" flash
